### PR TITLE
Create setup_cert_auth.py and ssh_diag.sh

### DIFF
--- a/tools/setup_cert_auth.py
+++ b/tools/setup_cert_auth.py
@@ -1,0 +1,111 @@
+"""
+Description: This script is to enable certificate based auth on SSH host(Linux server) to be accessed using Ubyon Link
+Author: Ubyon Inc
+"""
+import requests
+import os
+import sys
+import distro
+import argparse
+
+ubcookie = None
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-s", "--host", default='manage.ubyon.com', help="Ubyon management portal FQDN")
+parser.add_argument("-k", "--api-key-id", required=True, help="Ubyon Service account key ID")
+parser.add_argument("-n", "--ssh-cert-key-name", required=True, help="SSH certificate key name")
+parser.add_argument("-l", "--ssh-login-id", required=True, help="End user's SSH login id")
+parser.add_argument("-p", "--ssh-principal", required=True, help="End user's auth principal name")
+
+
+def login():
+    """
+    This method logs into the Ubyon system in order to run the REST API
+    """
+    headers = {
+        'X-UBY-APIKEY': args.api_key_id
+    }
+    url = "https://{}/api/v1/login".format(args.host)
+    response = requests.request("POST", url, headers=headers)
+    print(response.status_code)
+    if response.status_code != 204:
+        print("Login failed, exiting")
+        exit(1)
+    cookie_dict = response.cookies.get_dict()
+    ubsession = cookie_dict.get('ubsession')
+    ubsession_2 = cookie_dict.get('ubsession_2')
+    global ubcookie
+    ubcookie = "ubsession={}; ubsession_2={}".format(ubsession, ubsession_2)
+
+
+def get_ssh_key():
+    """
+    This method retrieves the SSH certificate's userKey using the REST API provided by Ubyon and writes the same to
+    /etc/ssh/ca_cert.pub file
+    """
+    headers = {
+        'Cookie': ubcookie
+    }
+    url = "https://{}/ssh-ca/v1/signing-keys".format(args.host)
+    response = requests.request('GET', url, headers=headers)
+    res_json = response.json()
+    for key in res_json:
+        if key['keyName'] == args.ssh_cert_key_name:
+            print(key['keyName'], key['userKey'])
+            f = open('/etc/ssh/ca_cert.pub', 'w+')
+            f.write(key['userKey'])
+            f.close()
+        else:
+            print("Unable to fetch the SSH keys from Ubyon, please try again after sometime")
+
+
+def modify_host():
+    """
+    This method performs the below operations:
+    1. Modifies the sshd configuration
+    2. Enables the certificate based auth for SSH
+    3. Creates mapping of ssh login id to user's auth principal
+    4. Restarts ssh service
+    :return:
+    """
+    ssh_cfg_dir = '/etc/ssh'
+    ssh_cfg_file = '{}/sshd_config'.format(ssh_cfg_dir)
+    auth_principal_dir = '{}/auth_principals'.format(ssh_cfg_dir)
+    auth_principal_file = '{}/{}'.format(auth_principal_dir, args.ssh_login_id)
+    # Create auth_principals dir and its mapping file
+    if not os.path.exists(auth_principal_dir):
+        os.mkdir(auth_principal_dir)
+    f = open(auth_principal_file, 'a+')
+    f.write(args.ssh_principal+'\n')
+    f.close()
+    # Modify the sshd_config file to enable certificate based auth
+    with open(ssh_cfg_file, "r+") as file:
+        for line in file:
+            if 'TrustedUserCAKeys /etc/ssh/ca_cert.pub' in line:
+                print('Certificate auth is already enabled, not going to modifying the sshd_config')
+                break
+        else:
+            file.write('TrustedUserCAKeys /etc/ssh/ca_cert.pub'+'\n')
+        for line in file:
+            if 'AuthorizedPrincipalsFile /etc/ssh/auth_principals/%u' in line:
+                print('Auth principals config present, not going to modifying the sshd_config')
+                break
+        else:
+            file.write('AuthorizedPrincipalsFile /etc/ssh/auth_principals/%u'+'\n')
+    # Restart ssh service
+    if (distro.id()).lower() == 'ubuntu':
+        os.system('sudo systemctl restart ssh')
+    elif (distro.id()).lower() == 'centos':
+        os.system('sudo service sshd restart')
+
+
+def main():
+    login()
+    get_ssh_key()
+    modify_host()
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    sys.exit(main())
+

--- a/tools/ssh_diag.sh
+++ b/tools/ssh_diag.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+if [[ ( $@ == "--help") ||  $@ == "-h" ]]; then
+	    echo "Usage: $0 ssh_login_id ssh_principal"
+	        echo "Example: $0 ubuntu foo.bar"
+		    exit 0
+fi
+if [  $# -le 1 ]; then
+	    echo "Usage: $0 ssh_login_id ssh_principal"
+	        echo "Example: $0 ubuntu foo.bar"
+		    exit 1
+fi
+
+red=`tput setaf 1`
+green=`tput setaf 2`
+reset=`tput sgr0`
+
+# Detect OS
+os=`lsb_release -si`
+printf "${green}Running system diagnostics${reset}"
+printf "\n*** General system details ***\n"
+echo "Operating system: $os"
+echo "Current time: $(date)"
+ssh -V
+echo "SSH service status:"
+service sshd status | grep -i active
+echo "System memory available: $(free -m | awk '/^Mem:/{printf("%.1fGb\n",$7/1000)}')"
+#Check certificate based auth config in sshd_config
+printf "\n*** SSH configuration file ***\n\n"
+grep "TrustedUserCAKeys" /etc/ssh/sshd_config
+grep "AuthorizedPrincipalsFile" /etc/ssh/sshd_config
+echo "SSH config file was last modified on: $(date -r /etc/ssh/sshd_config)"
+#Check auth_principals dir
+printf "\n*** Auth principals directory check ***\n"
+if [ -d "/etc/ssh/auth_principals" ] 
+then
+    printf "\nChecking auth_principals directory: ${green}PASS\n${reset}" 
+else
+    printf "\nChecking auth_principals directory: ${red}FAILED\n${reset}" 
+fi
+#Check ca_cert.pub 
+printf "\n*** Trusted user CA keys check ***\n"
+if [ -e "/etc/ssh/ca_cert.pub" ]
+then
+    printf "\nChecking ca_cert.pub: ${green}PASS\n${reset}"
+else
+    printf "\nChecking ca_cert.pub: ${red}FAILED\n${reset}"
+fi
+if [ $# -eq 2 ]
+  then
+	printf "\n*** Auth principal name check ***\n"
+	if [ -e "/etc/ssh/auth_principals/$1" ]
+	then
+    		printf "\nAuth principals file detection for user $1: ${green}PASS\n${reset}"
+	else
+    		printf "\nAuth principals file detection for user $1: ${red}FAILED\n${reset}"
+    		exit 1
+	fi
+	for f in /etc/ssh/auth_principals/$1
+	do
+		#Check if user to auth principal mapping is correct
+		if grep -wiq $2 "$f"; then
+	        	printf "User to auth principals mapping: ${green} PASS ${reset}"
+		else
+			printf "User to auth principals mapping: ${red} FAILED ${reset}"
+        	fi
+		#Check if auth principal files contain domain names
+		if grep -irql @ "$f"; then
+			printf "\nAuth principal detected for user `basename $f` ${red}is INVALID \n${reset}"
+			printf "${red}--Error: make sure the principal name in cert matches the principal in $f\n${reset}"
+		fi
+	done
+	printf "\n\n*** Authentication logs for user $1/$2 ***\n"
+    	tail -10 /var/log/auth.log | grep $1
+    	tail -10 /var/log/auth.log | grep $2
+fi
+printf "\n${green}*** Diagnostics completed ***\n${reset}"


### PR DESCRIPTION
Script to enable certificate based auth on a Linux host
1. Takes the inputs as - service account key, ssh login id and principal name
2. Modifies the sshd_config, gets the ssh key from Ubyon using DX API and configures cert based auth
3. Restarts ssh server